### PR TITLE
Hide broken mustache command via forked hubot-help at joiggama/hubot-help

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,6 @@ export HUBOT_AUTH_ADMIN="joiggama"
 export HUBOT_GOOGLE_CSE_ID=""
 export HUBOT_GOOGLE_CSE_KEY=""
 
+export HUBOT_HELP_HIDDEN_COMMANDS="mustache me \<url\|query\>"
+
 export HUBOT_HEROKU_KEEPALIVE_URL="http://reylero.magmalabs.dev"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "coffee-script": "~1.11.1",
     "hubot": "~2.19.0",
+    "hubot-help": "git+https://github.com/joiggama/hubot-help.git#hide-commands",
     "hubot-auth": "~1.2.0",
     "hubot-google-images": "~0.2.6",
     "hubot-heroku-keepalive": "~1.0.0",


### PR DESCRIPTION
Hides unused/broken command  (mustache me ) from displaying in help list:

    reylero help

> reylero> Shell: reylero <user> doesn't have <role> role - Removes a role from a user
reylero <user> has <role> role - Assigns a role to a user
reylero animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
reylero help - Displays all of the help commands that Hubot knows about.
reylero help <query> - Displays all help commands that match <query>.
reylero image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
reylero map me <query> - Returns a map view of the area returned by `query`.
reylero sdt group submit with <username> <topic>- Submit a group talk proposal
reylero sdt schedule - Show current session schedule
reylero sdt schedule clear - (admin) Clear current session schedule
reylero sdt sessions [list] [n] - List last n sessions with schedules
reylero sdt sessions create <Sep 15 2015> - (admin) Create a session
reylero sdt submit <topic> - Submit a talk proposal
reylero the rules - Make sure hubot still knows the rules.
reylero what roles do I have - Find out what roles you have
reylero what roles does <user> have - Find out what roles a user has
reylero who has <role> role - Find out who has the given role    

    

